### PR TITLE
Make privacy policy and help pages public

### DIFF
--- a/cypress/e2e/public-pages.cy.ts
+++ b/cypress/e2e/public-pages.cy.ts
@@ -1,0 +1,42 @@
+import { apiInterceptor } from 'cypress/api/ApiInterceptor'
+
+describe('Public Pages', () => {
+    describe('unauthenticated visitors', () => {
+        beforeEach(() => {
+            apiInterceptor.interceptGetUserDetails({ status: 401 })
+        })
+
+        it('can view the privacy policy without being redirected to login', () => {
+            cy.visit('/privacy-policy')
+
+            cy.location('pathname', { timeout: 60000 }).should('eq', '/privacy-policy')
+
+            cy.contains('Privacy Policy').should('be.visible')
+            cy.contains('Information We Collect').should('be.visible')
+
+            // No account menu for a logged-out visitor
+            cy.getById('top-bar').should('be.visible')
+            cy.getById('top-bar-account-btn').should('not.exist')
+        })
+
+        it('can view the help page without being redirected to login', () => {
+            cy.visit('/help')
+
+            cy.location('pathname', { timeout: 60000 }).should('eq', '/help')
+
+            cy.contains('Help Page').should('be.visible')
+        })
+    })
+
+    describe('authenticated users', () => {
+        it('still see the account menu on the privacy policy page', () => {
+            apiInterceptor.interceptGetUserDetails({})
+
+            cy.visit('/privacy-policy')
+
+            cy.location('pathname', { timeout: 60000 }).should('eq', '/privacy-policy')
+
+            cy.getById('top-bar-account-btn').should('be.visible')
+        })
+    })
+})

--- a/src/forms/CreateGuestUserForm/CreateGuestUserForm.tsx
+++ b/src/forms/CreateGuestUserForm/CreateGuestUserForm.tsx
@@ -7,19 +7,26 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import classes from './CreateGuestUserForm.module.scss'
 import { InputErrorMessage } from 'components/InputErrorMessage/InputErrorMessage'
 import { toast } from 'react-toastify'
+import { useNavigate } from 'react-router'
+import { useUserDetailsContext } from 'provider/UserDetailsProvider/useUserDetailsContext'
 
 export const CreateGuestUserForm = () => {
     const { register, handleSubmit, formState: { errors } } = useForm<CreateGuestUserFormFields>({
         resolver: yupResolver(schema)
     })
     const { mutateAsync: signUpAsGuest, isPending } = useSignUpAsGuest()
+    const { invalidateUserDetails } = useUserDetailsContext()
+    const navigate = useNavigate()
     const testIdKey = 'login-page'
 
     const createGuestUser = handleSubmit(
         async ({ firstName, lastName }) => {
             await signUpAsGuest({ firstName, lastName })
-                .then(() => {
-                    window.location.href = '/dashboard'
+                .then(async () => {
+                    // Refresh the (previously failed) user-details query before
+                    // navigating, so the auth redirect sees the new session.
+                    await invalidateUserDetails()
+                    navigate('/dashboard')
                 })
                 .catch(() => {
                     toast('Something went wrong! Unable to create a guest account.', {

--- a/src/hooks/useDeleteAccount/useDeleteAccount.ts
+++ b/src/hooks/useDeleteAccount/useDeleteAccount.ts
@@ -7,6 +7,8 @@ export const useDeleteAccount = () => {
 
     const deleteAccount = useCallback(async () => {
         await webClient.delete('/v1/users').then(() => {
+            // Deliberate full-page redirect: it drops the react-query cache
+            // so no user data survives the account deletion.
             window.location.href = '/login'
         })
     }, [])

--- a/src/hooks/useLogout/useLogout.ts
+++ b/src/hooks/useLogout/useLogout.ts
@@ -8,6 +8,8 @@ export const useLogout = () => {
     const logout = useCallback(async () => {
         await webClient.get('/logout').then((result) => {
             if(result.status === 204) {
+                // Deliberate full-page redirect: it drops the react-query cache
+                // so no user data survives the logout.
                 window.location.href = '/login'
             }
         })

--- a/src/modules/TopBar/TopBar.tsx
+++ b/src/modules/TopBar/TopBar.tsx
@@ -4,14 +4,19 @@ import { AccountBar } from 'components/AccountBar'
 import { HelpBar } from 'components/HelpBar'
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined'
 import { TopBarProps } from './types'
+import { useNavigate } from 'react-router'
+import { useUserDetailsContext } from 'provider/UserDetailsProvider/useUserDetailsContext'
 
 export const TopBar = ({
     showHomeButton = false,
     showHelpButton = true,
     showAccountButton = true
 }: TopBarProps) => {
+    const navigate = useNavigate()
+    const { userDetails } = useUserDetailsContext()
+
     const redirectToHome = () => {
-        window.location.href = '/dashboard'
+        navigate('/dashboard')
     }
     return(
         <AppBar className={classes.TopBar} data-testid='top-bar' sx={{ position: 'sticky', zIndex: (theme) => theme.zIndex.drawer + 1 }}>
@@ -41,7 +46,9 @@ export const TopBar = ({
                     {showHelpButton && (
                         <HelpBar />
                     )}
-                    {showAccountButton && (
+                    {/* The account menu is meaningless without a logged-in user
+                        (e.g. an unauthenticated visitor on a public page). */}
+                    {showAccountButton && userDetails && (
                         <AccountBar />
                     )}
                 </Box>

--- a/src/pages/PrintableTripPage/PrintableTripPage.tsx
+++ b/src/pages/PrintableTripPage/PrintableTripPage.tsx
@@ -1,5 +1,6 @@
 import classes from './PrintableTripPage.module.scss'
 import { useEffect, useMemo, useRef } from 'react'
+import { useNavigate } from 'react-router'
 import { SelectedOptionsMap } from 'provider/TripStateProvider/TripStateContext'
 import { TripNotFoundError } from 'modules/TripNotFoundError'
 import { LoadingBackdrop } from 'modules/LoadingBackdrop'
@@ -18,6 +19,7 @@ import { PrintableAccommCard } from './PrintableElements/PrintableAccommCard'
 
 export const PrintableTripPage = () => {
 
+    const navigate = useNavigate()
     const { tripId } = useTripId()
     const { data: trip, isLoading, isError } = useGetTrip({ tripId: tripId })
 
@@ -52,7 +54,7 @@ export const PrintableTripPage = () => {
     }
 
     const redirectToHome = () => {
-        window.location.href = '/dashboard'
+        navigate('/dashboard')
     }
 
     return (

--- a/src/pages/PrivacyPolicy/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicy/PrivacyPolicyPage.tsx
@@ -92,9 +92,9 @@ export const PrivacyPolicyPage = () => {
             </Box>
 
             <Box mb={4}>
-                <Typography variant="h6">7. Contact Us</Typography>
+                <Typography variant="h6">7. Managing Your Data</Typography>
                 <Typography>
-                    If you have questions or concerns about this policy or your data, please do not contact us at.
+                    All data access, update, and deletion actions are self-service via the account menu (see Section 3).
                 </Typography>
             </Box>
         </Box>

--- a/src/provider/UserDetailsProvider/UserDetailsProvider.tsx
+++ b/src/provider/UserDetailsProvider/UserDetailsProvider.tsx
@@ -8,6 +8,9 @@ interface UserDetailsProviderProps {
     children: React.ReactNode
 }
 
+// Pages that are viewable without being logged in.
+const PUBLIC_PATHS = ['/login', '/privacy-policy', '/help']
+
 export const UserDetailsProvider = ({ children }: UserDetailsProviderProps) => {
     const { data: userDetails, isSuccess, isError } = useGetUserDetails()
     const queryClient = useQueryClient()
@@ -17,7 +20,7 @@ export const UserDetailsProvider = ({ children }: UserDetailsProviderProps) => {
             window.location.href = '/dashboard'
         }
 
-        if (isError && window.location.pathname !== '/login') {
+        if (isError && !PUBLIC_PATHS.includes(window.location.pathname)) {
             window.location.href = '/login'
         }
     }, [isSuccess, isError])


### PR DESCRIPTION
## Summary
- Allow unauthenticated visitors to view `/privacy-policy` and `/help` (public-path allowlist in `UserDetailsProvider`); the TopBar hides the account menu when nobody is logged in
- Fix the unfinished privacy-policy contact copy (data rights are self-service via the account menu)
- Replace full-page `window.location.href` redirects with router navigation where safe (TopBar home, guest signup, printable page); logout/account-deletion keep the full reload deliberately to drop the react-query cache
- Add a `public-pages` Cypress spec covering unauthenticated access and the authenticated account-menu behaviour

Phase 3 of CLEANUP_PLAN.md (Public Route And First-Visit UX).

## Verification
- npm run lint:ci
- npx tsc --noEmit
- npm run test:coverage (17/17)
- Cypress locally: public-pages, login-page, top-bar, passengers, trips-view specs all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)