### PR TITLE
Repo hygiene: ignores, env sample, README, web metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL of the Itinerary Hub API
+VITE_API_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -8,14 +8,18 @@
 # testing
 /coverage
 /coverage-unit
+/.nyc_output
 
 /cypress/downloads
 
 # production
 /build
+/dist
+/.vercel
 
 # misc
 .DS_Store
+*~
 .env
 .env.local
 .env.development.local

--- a/README.md
+++ b/README.md
@@ -1,16 +1,46 @@
 [![codecov](https://codecov.io/gh/natalia-KM/itinerary-hub-frontend/graph/badge.svg?token=JNNKI0JDvE)](https://codecov.io/gh/natalia-KM/itinerary-hub-frontend)
 
-# Itinerary Hub FE
+# Itinerary Hub Frontend
 
-The client for the Itinerary Hub
+Itinerary Hub is a React app for planning trips, comparing itinerary options, managing passengers, and printing a travel plan.
 
-### Start up the app
+## Tech Stack
 
-### `npm install`
+- React 19
+- Vite
+- TypeScript
+- MUI
+- TanStack Query
+- Vitest
+- Cypress
 
-### `npm start`
+## Local Setup
 
-### Notes
+Install dependencies:
 
-Sometimes Cypress tests fail due to vercel plugin for vite. 
-The plugin is unfortunately needed for deploys, so to run tests locally, remove 'vercel()' from plugins in vite config file
+```bash
+npm install
+```
+
+Create local environment values:
+
+```bash
+cp .env.example .env.local
+```
+
+Start the app:
+
+```bash
+npm start
+```
+
+The app runs at `http://localhost:3000` by default.
+
+## Useful Commands
+
+```bash
+npm run lint
+npm run build
+npm test -- --run
+npm run cypress:run
+```

--- a/index.html
+++ b/index.html
@@ -3,17 +3,16 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#1976d2" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Plan trips, compare itinerary options, manage passengers, and print travel plans with Itinerary Hub."
     />
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="shortcut icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <link rel="manifest" href="/manifest.json" />
 
     <title>Itinerary Hub</title>
   </head>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Itinerary Hub",
+  "name": "Itinerary Hub",
   "icons": [
     {
       "src": "favicon.ico",
@@ -18,8 +18,8 @@
       "sizes": "512x512"
     }
   ],
-  "start_url": ".",
+  "start_url": "/",
   "display": "standalone",
-  "theme_color": "#000000",
+  "theme_color": "#1976d2",
   "background_color": "#ffffff"
 }

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,21 +1,22 @@
 {
-  "name": "ItineraryHub",
-  "short_name": "ItHub",
+  "name": "Itinerary Hub",
+  "short_name": "Itinerary Hub",
   "icons": [
     {
-      "src": "/web-app-manifest-192x192.png",
+      "src": "/logo192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/web-app-manifest-512x512.png",
+      "src": "/logo512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#ffffff",
+  "start_url": "/",
+  "theme_color": "#1976d2",
   "background_color": "#ffffff",
   "display": "standalone"
 }


### PR DESCRIPTION
## Summary
- Ignore generated output and editor backup files (`/dist`, `/.vercel`, `/.nyc_output`, `*~`)
- Add `.env.example` documenting `VITE_API_URL`
- Refresh the README (description, tech stack, setup, useful commands)
- Replace stale CRA browser metadata (description, theme colour, manifest names/icons; drop duplicate manifest link)

Ships the phase-1 work from CLEANUP_PLAN.md that was completed locally but never pushed. With this, all 5 phases of the plan are actually merged.

## Verification
- npm run build
- npm run lint:ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)